### PR TITLE
Add support for Google Additional Consent Mode (GACM)

### DIFF
--- a/modules/cmpapi/src/CmpApi.ts
+++ b/modules/cmpapi/src/CmpApi.ts
@@ -52,7 +52,7 @@ export class CmpApi {
    * for eventStatus and displayStatus.
    * @return {void}
    */
-  public update(encodedTCString: string | null, uiVisible = false): void {
+  public update(encodedTCString: string | null, uiVisible = false, addtlConsent: string): void {
 
     if (CmpApiModel.disabled) {
 
@@ -107,6 +107,10 @@ export class CmpApi {
       CmpApiModel.tcfPolicyVersion = Number(CmpApiModel.tcModel.policyVersion);
       CmpApiModel.tcString = encodedTCString;
 
+    }
+
+    if (addtlConsent) {
+      CmpApiModel.addtlConsent = addtlConsent;
     }
 
     if (this.numUpdates === 0) {

--- a/modules/cmpapi/src/CmpApiModel.ts
+++ b/modules/cmpapi/src/CmpApiModel.ts
@@ -22,6 +22,7 @@ export class CmpApiModel {
   public static gdprApplies: boolean;
   public static tcModel: TCModel;
   public static tcString: string;
+  public static addtlConsent: string;
 
   public static reset(): void {
 
@@ -31,6 +32,7 @@ export class CmpApiModel {
     delete this.gdprApplies;
     delete this.tcModel;
     delete this.tcString;
+    delete this.addtlConsent;
     delete this.tcfPolicyVersion;
 
     this.cmpStatus = CmpStatus.LOADING;

--- a/modules/cmpapi/src/response/TCData.ts
+++ b/modules/cmpapi/src/response/TCData.ts
@@ -57,6 +57,8 @@ export class TCData extends Response {
 
   };
 
+  public addtlConsent: string;
+
   /**
    * Constructor to create a TCData object from a TCModel
    * @param {number[]} vendorIds - if not undefined, will be used to filter vendor ids
@@ -115,7 +117,9 @@ export class TCData extends Response {
         },
         restrictions: this.createRestrictions(tcModel.publisherRestrictions),
 
-      };
+      },
+
+      this.addtlConsent = CmpApiModel.addtlConsent;
 
     }
 


### PR DESCRIPTION
Add support for Google Additional Consent Mode (GACM). These are modifications to the original CMP API to support Googles addition to the framework: https://support.google.com/admanager/answer/9681920